### PR TITLE
Fix/sign transaction bug

### DIFF
--- a/eosc/cmd/common.go
+++ b/eosc/cmd/common.go
@@ -149,7 +149,7 @@ func optionallySudoWrap(tx *eos.Transaction, opts *eos.TxOptions) *eos.Transacti
 func optionallySignTransaction(tx *eos.Transaction, chainID eos.SHA256Bytes, api *eos.API) (signedTx *eos.SignedTransaction, packedTx *eos.PackedTransaction) {
 	if !viper.GetBool("global-skip-sign") {
 		textSignKeys := viper.GetStringSlice("global-offline-sign-key")
-		if textSignKeys != nil {
+		if len(textSignKeys) > 0 {
 			var signKeys []ecc.PublicKey
 			for _, key := range textSignKeys {
 				pubKey, err := ecc.NewPublicKey(key)


### PR DESCRIPTION
A bug with the new `offline-sign-key` parameter was causing the custom `GetRequiredKeys` handler to set making it impossible to correctly sign transaction meant to be pushed to the chain.

The problem was the the parameter has been converted from a string to a string slice and the default value being the empty string slice.

The signing process was incorrectly checking for the parameter being nil instead of checking for being the empty slice.

This is now fixed.