### PR TITLE
Add system subcommands: regproxy, unregproxy

### DIFF
--- a/eosc/cmd/systemRegproxy.go
+++ b/eosc/cmd/systemRegproxy.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/eoscanada/eos-go/system"
+	"github.com/spf13/cobra"
+)
+
+var systemRegisterProxyCmd = &cobra.Command{
+	Use:   "regproxy [account_name]",
+	Short: "Register an account as a voting proxy",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		api := getAPI()
+		accountName := toAccount(args[0], "account name")
+		pushEOSCActions(api,
+			system.NewRegProxy(accountName, true),
+		)
+	},
+}
+
+func init() {
+	systemCmd.AddCommand(systemRegisterProxyCmd)
+}

--- a/eosc/cmd/systemUnregproxy.go
+++ b/eosc/cmd/systemUnregproxy.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/eoscanada/eos-go/system"
+	"github.com/spf13/cobra"
+)
+
+var systemUnregisterProxyCmd = &cobra.Command{
+	Use:   "unregproxy [account_name]",
+	Short: "Unregister account as voting proxy.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		api := getAPI()
+		accountName := toAccount(args[0], "account name")
+		pushEOSCActions(api, system.NewRegProxy(accountName, false))
+	},
+}
+
+func init() {
+	systemCmd.AddCommand(systemUnregisterProxyCmd)
+}

--- a/vendor/github.com/eoscanada/eos-go/README-cn.md
+++ b/vendor/github.com/eoscanada/eos-go/README-cn.md
@@ -1,4 +1,4 @@
-EOS.IO API 库
+用 Go 语言与 EOS.IO 交互的 API 库
 =========================
 
 [![GoDoc](https://godoc.org/github.com/eoscanada/eos-go?status.svg)](https://godoc.org/github.com/eoscanada/eos-go)

--- a/vendor/github.com/eoscanada/eos-go/responses.go
+++ b/vendor/github.com/eoscanada/eos-go/responses.go
@@ -354,8 +354,8 @@ type ProducersResp struct {
 }
 type GetActionsRequest struct {
 	AccountName AccountName `json:"account_name"`
-	Pos         int64       `json:"pos,omitempty"`
-	Offset      int64       `json:"offset,omitempty"`
+	Pos         int64       `json:"pos"`
+	Offset      int64       `json:"offset"`
 }
 type ActionResp struct {
 	GlobalSeq  int64       `json:"global_action_seq"`

--- a/vendor/github.com/eoscanada/eos-go/system/init.go
+++ b/vendor/github.com/eoscanada/eos-go/system/init.go
@@ -14,7 +14,6 @@ func init() {
 	eos.RegisterAction(AN("eosio"), ActN("regproducer"), RegProducer{})
 	eos.RegisterAction(AN("eosio"), ActN("unregprod"), UnregProducer{})
 	eos.RegisterAction(AN("eosio"), ActN("regproxy"), RegProxy{})
-	eos.RegisterAction(AN("eosio"), ActN("unregproxy"), UnregProxy{})
 	eos.RegisterAction(AN("eosio"), ActN("voteproducer"), VoteProducer{})
 	eos.RegisterAction(AN("eosio"), ActN("claimrewards"), ClaimRewards{})
 	eos.RegisterAction(AN("eosio"), ActN("buyram"), BuyRAM{})

--- a/vendor/github.com/eoscanada/eos-go/system/types.go
+++ b/vendor/github.com/eoscanada/eos-go/system/types.go
@@ -1,9 +1,5 @@
 package system
 
-import (
-	eos "github.com/eoscanada/eos-go"
-)
-
 // BlockchainParameters are all the params we can set through `setparams`.
 type BlockchainParameters struct {
 	MaxBlockNetUsage               uint64 `json:"max_block_net_usage"`
@@ -34,11 +30,6 @@ type EOSIOGlobalState struct {
 	TotalStorageBytesReserved uint64 `json:"total_storage_bytes_reserved"`
 	TotalStorageStake         uint64 `json:"total_storage_stake"`
 	PaymentPerBlock           uint64 `json:"payment_per_block"`
-}
-
-// UnregProxy represents the `eosio.system::unregproxy` action
-type UnregProxy struct {
-	Proxy eos.AccountName `json:"proxy"`
 }
 
 // Nonce represents the `eosio.system::nonce` action. It is used to

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,72 +21,71 @@
 			"revisionTime": "2018-02-21T22:46:20Z"
 		},
 		{
-			"checksumSHA1": "8LzAFyaqFWMLu5ZCdVeVTURsjAQ=",
+			"checksumSHA1": "tDDahwhmQCFy2+n4BYti9QyahR0=",
 			"path": "github.com/eoscanada/eos-go",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z",
-			"version": "feature/direct-hex-data-in-action-data",
-			"versionExact": "feature/direct-hex-data-in-action-data"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z",
+			"version": "master"
 		},
 		{
 			"checksumSHA1": "mbdurDenl8bhRVVu8ixJw70fi5E=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcd/btcec",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "9CdGdJ/+qjIwCfyoxoB3JxNtdyg=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcutil",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "VkjW+vswsv7J0PX2UFqqg+/RVgs=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcutil/base58",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "zM0evxNx+urvLIkrJ3G9UdHNiUo=",
 			"path": "github.com/eoscanada/eos-go/ecc",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "GVFGhEfGI9Rpz6KF+c4S2YqAojI=",
 			"path": "github.com/eoscanada/eos-go/forum",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "Gk4Dvc3QqbWnUdz4jvCXuxULqyo=",
 			"path": "github.com/eoscanada/eos-go/msig",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
-			"checksumSHA1": "WU8hVzgZvwkfNW0ExzkHbEZqTN8=",
+			"checksumSHA1": "ZlOxKqupmFMIsaj0iPYFNTTDkgI=",
 			"path": "github.com/eoscanada/eos-go/p2p",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "k9urFt9aTmOSSOfM8HCd178pbmM=",
 			"path": "github.com/eoscanada/eos-go/sudo",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
-			"checksumSHA1": "GS788IvHWUqr2SmXkCVSYb90A68=",
+			"checksumSHA1": "INVxgDwm7w2DfWELXYgyj87PSEE=",
 			"path": "github.com/eoscanada/eos-go/system",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "n/7xl3TEdpCXXT0GtNAxva/ReoI=",
 			"path": "github.com/eoscanada/eos-go/token",
-			"revision": "98e345de65d95124be3063f83bb782058c927080",
-			"revisionTime": "2018-08-29T20:10:18Z"
+			"revision": "1af6c814612fbcf3dd49df0dccddf45108a6d628",
+			"revisionTime": "2018-09-06T19:53:53Z"
 		},
 		{
 			"checksumSHA1": "7NP1qUMF8Kx1y0zANxx0e+oq9Oo=",


### PR DESCRIPTION
Updated vendored eos-go.
Added regproxy / unregproxy commands.

Sample usage on Kylin:
`eosc --api-url=https://kylin.eocanada.com system regproxy nectarineboo`
`eosc --api-url=https://kylin.eocanada.com system unregproxy nectarineboo`

Validate state change in `eosio` voters table:
`curl -X POST https://kylin.eoscanada.com/v1/chain/get_table_rows -d '{"json":true,"code":"eosio","scope":"eosio","table":"voters","key_type":"name","lower_bound":"nectarineboo","upper_bound":"nectarinebop"}' | jq .is_proxy`

Resolves #33 
