### PR TITLE
Added global flag --delay-sec

### DIFF
--- a/eosc/cmd/common.go
+++ b/eosc/cmd/common.go
@@ -121,6 +121,10 @@ func pushEOSCActions(api *eos.API, actions ...*eos.Action) {
 		opts.HeadBlockID = toSHA256Bytes(headBlockID, "--offline-head-block")
 	}
 
+	if delaySec := viper.GetInt("global-delay-sec"); delaySec != 0 {
+		opts.DelaySecs = uint32(delaySec)
+	}
+
 	if err := opts.FillFromChain(api); err != nil {
 		fmt.Println("Error fetching tapos + chain_id from the chain (specify --offline flags for offline operations):", err)
 		os.Exit(1)

--- a/eosc/cmd/root.go
+++ b/eosc/cmd/root.go
@@ -51,9 +51,10 @@ func init() {
 	RootCmd.PersistentFlags().StringSliceP("offline-sign-key", "", []string{}, "Public key to use to sign transaction. Must be in your vault or wallet. Use all --offline- options to sign transactions offline.")
 	RootCmd.PersistentFlags().BoolP("skip-sign", "", false, "Do not sign the transaction. Use with --write-transaction.")
 	RootCmd.PersistentFlags().IntP("expiration", "", 30, "Set time before transaction expires, in seconds. Defaults to 30 seconds.")
+	RootCmd.PersistentFlags().IntP("delay-sec", "", 0, "Set time to wait before transaction is executed, in seconds. Defaults to 0 second.")
 	RootCmd.PersistentFlags().BoolP("sudo-wrap", "", false, "Wrap the transaction in a eosio.sudo exec. Useful to BPs, with --write-transaction and --skip-sign to then submit as a multisig proposition.")
 
-	for _, flag := range []string{"vault-file", "api-url", "kms-gcp-keypath", "wallet-url", "permission", "expiration", "write-transaction", "skip-sign", "offline-head-block", "offline-chain-id", "offline-sign-key", "sudo-wrap"} {
+	for _, flag := range []string{"vault-file", "api-url", "kms-gcp-keypath", "wallet-url", "permission", "expiration", "delay-sec", "write-transaction", "skip-sign", "offline-head-block", "offline-chain-id", "offline-sign-key", "sudo-wrap"} {
 		if err := viper.BindPFlag("global-"+flag, RootCmd.PersistentFlags().Lookup(flag)); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
New global flag that adds an arbitrary delay to  any transaction on chain.

Tested on Kylin:
`eosck transfer nectarineboo nectarinecom 77 --delay-sec=120`
`eosck transfer nectarineboo nectarinecom 88`

Transfer of 88 appears on EOSQuery before the 77.

---
Resolves #41 