### PR TITLE
Added system canceldelay to cancel delayed transactions

### DIFF
--- a/eosc/cmd/common.go
+++ b/eosc/cmd/common.go
@@ -250,6 +250,14 @@ func toName(in, field string) eos.Name {
 	return name
 }
 
+func toPermissionLevel(in, field string) eos.PermissionLevel {
+	perm, err := permissionToPermissionLevel(in)
+	if err != nil {
+		errorCheck(fmt.Sprintf("invalid permission level for %q", field), err)
+	}
+	return perm
+}
+
 func toActionName(in, field string) eos.ActionName {
 	return eos.ActionName(toName(in, field))
 }

--- a/eosc/cmd/msigStatus.go
+++ b/eosc/cmd/msigStatus.go
@@ -49,7 +49,6 @@ var msigStatusCmd = &cobra.Command{
 					data, err := json.MarshalIndent(info, "", "  ")
 					errorCheck("json marshal", err)
 					fmt.Println(string(data))
-					return
 				} else {
 					fmt.Println("Proposer:", proposer)
 					fmt.Println("Proposal name:", proposalName)

--- a/eosc/cmd/systemCanceldelay.go
+++ b/eosc/cmd/systemCanceldelay.go
@@ -1,0 +1,25 @@
+// Copyright © 2018 EOS Canada <info@eoscanada.com>
+
+package cmd
+
+import (
+	"github.com/eoscanada/eos-go/system"
+	"github.com/spf13/cobra"
+)
+
+var systemCanceldelayCmd = &cobra.Command{
+	Use:   `canceldelay [cancelling_authority] [transaction_id]`,
+	Short: "Cancels a delayed transaction.",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		authority := toPermissionLevel(args[0], "cancelling_authority")
+		transactionID := toSHA256Bytes(args[1], "transaction_id")
+
+		api := getAPI()
+		pushEOSCActions(api, system.NewCancelDelay(authority, transactionID))
+	},
+}
+
+func init() {
+	systemCmd.AddCommand(systemCanceldelayCmd)
+}


### PR DESCRIPTION
Tested on Kylin.

Current behavior on EOSQuery is strange - see https://github.com/eoscanada/eosquery/issues/89

---
```
$ eosc --api-url=https://kylin.eoscanada.com transfer nectarineboo nectarinecom 4 --vault-file=$HOME/vaults/kylin-nectarineboo-vault.json --delay-sec=30
Enter passphrase to decrypt your vault:
Transaction submitted to the network. Transaction ID: d2295e1438038e81a24323402381e638a375be59f5c8e7d165f0866a6f2b997b
```

```
$ eosc --api-url=https://kylin.eoscanada.com system canceldelay nectarineboo d2295e1438038e81a24323402381e638a375be59f5c8e7d165f0866a6f2b997b --vault-file=$HOME/vaults/kylin-nectarineboo-vault.json
Enter passphrase to decrypt your vault:
Transaction submitted to the network. Transaction ID: f66b8e7620a93e8dd5d21bef400804ab7e5b92130f104b04c3bad28a9681fae4
```