### PR TITLE
Minor changes to vote and help consistency updates

### DIFF
--- a/eosc/cmd/systemBidname.go
+++ b/eosc/cmd/systemBidname.go
@@ -10,7 +10,7 @@ import (
 
 var systemBidnameCmd = &cobra.Command{
 	Use:   "bidname [bidder_account_name] [premium_account_name] [bid quantity]",
-	Short: "Bid on a premium account name",
+	Short: "Bid on a premium account name.",
 	Long: `Bid on a premium account name
 
 All fields are required. Example usage:

--- a/eosc/cmd/systemLinkauth.go
+++ b/eosc/cmd/systemLinkauth.go
@@ -8,7 +8,7 @@ import (
 
 var systemLinkAuthCmd = &cobra.Command{
 	Use:   "linkauth [your account] [code account] [action name] [permission name]",
-	Short: "Assign a permission to the given code::action pair",
+	Short: "Assign a permission to the given code::action pair.",
 	Long: `Assign a permission to the given code::action pair.
 
 By default, accounts have an "owner" and "active" key and with the

--- a/eosc/cmd/systemNewaccount.go
+++ b/eosc/cmd/systemNewaccount.go
@@ -15,7 +15,7 @@ import (
 
 var systemNewAccountCmd = &cobra.Command{
 	Use:   "newaccount [creator] [new_account_name]",
-	Short: "Create a new account",
+	Short: "Create a new account.",
 	Long: `Create a new account
 
 Specify the authority structure with either '--auth-file' or '--auth-key'.

--- a/eosc/cmd/systemRegproducer.go
+++ b/eosc/cmd/systemRegproducer.go
@@ -11,7 +11,7 @@ import (
 
 var systemRegisterProducerCmd = &cobra.Command{
 	Use:   "regproducer [account_name] [public_key] [website_url]",
-	Short: "Register an account as a block producer candidate",
+	Short: "Register an account as a block producer candidate.",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/systemRegproxy.go
+++ b/eosc/cmd/systemRegproxy.go
@@ -7,7 +7,7 @@ import (
 
 var systemRegisterProxyCmd = &cobra.Command{
 	Use:   "regproxy [account_name]",
-	Short: "Register an account as a voting proxy",
+	Short: "Register an account as a voting proxy.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/systemSetabi.go
+++ b/eosc/cmd/systemSetabi.go
@@ -7,7 +7,7 @@ import (
 
 var systemSetabiCmd = &cobra.Command{
 	Use:   "setabi [account name] [abi file]",
-	Short: "Set ABI only on an account",
+	Short: "Set ABI only on an account.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/systemSetcode.go
+++ b/eosc/cmd/systemSetcode.go
@@ -7,7 +7,7 @@ import (
 
 var systemSetcodeCmd = &cobra.Command{
 	Use:   "setcode [account name] [wasm file]",
-	Short: "Set code only on an account",
+	Short: "Set code only on an account.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/systemSetcontract.go
+++ b/eosc/cmd/systemSetcontract.go
@@ -7,7 +7,7 @@ import (
 
 var systemSetcontractCmd = &cobra.Command{
 	Use:   "setcontract [account name] [wasm file] [abi file]",
-	Short: "Set both code and ABI on an account",
+	Short: "Set both code and ABI on an account.",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/systemUnlinkauth.go
+++ b/eosc/cmd/systemUnlinkauth.go
@@ -7,7 +7,7 @@ import (
 
 var systemUnlinkAuthCmd = &cobra.Command{
 	Use:   "unlinkauth [your account] [code account] [action name]",
-	Short: "Unassign a permission currently active for the given code::action pair",
+	Short: "Unassign a permission currently active for the given code::action pair.",
 	Long: `Unassign a permission currently active for the given code::action pair.
 
 This undoes the action of linkauth, please refer to the documentation for linkauth for more details.

--- a/eosc/cmd/vote.go
+++ b/eosc/cmd/vote.go
@@ -6,7 +6,7 @@ import (
 
 var voteCmd = &cobra.Command{
 	Use:   "vote",
-	Short: "Command to vote for block producers or proxy",
+	Short: "Command to vote for block producers or proxy.",
 }
 
 func init() {

--- a/eosc/cmd/voteCancelAll.go
+++ b/eosc/cmd/voteCancelAll.go
@@ -10,7 +10,7 @@ import (
 
 var voteCancelAllCmd = &cobra.Command{
 	Use:   "cancel-all [voter name]",
-	Short: "Cancel all votes currently casted for producers and reset proxy voting.",
+	Short: "Cancel all votes currently cast for producers/delegated to a proxy.",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/voteListProducers.go
+++ b/eosc/cmd/voteListProducers.go
@@ -17,7 +17,7 @@ import (
 
 var voteListProducersCmd = &cobra.Command{
 	Use:   "list-producers",
-	Short: "Retrieve the list of registered producers",
+	Short: "Retrieve the list of registered producers.",
 	Run:   run,
 }
 

--- a/eosc/cmd/voteProducers.go
+++ b/eosc/cmd/voteProducers.go
@@ -11,7 +11,7 @@ import (
 
 var voteProducersCmd = &cobra.Command{
 	Use:   "producers [voter name] [producer list]",
-	Short: "Cast your vote for 1 to 30 producers. View them with 'list'",
+	Short: "Cast your vote for 1 to 30 producers. View them with 'list-producers'.",
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/eosc/cmd/voteProxy.go
+++ b/eosc/cmd/voteProxy.go
@@ -9,7 +9,7 @@ import (
 
 var voteProxyCmd = &cobra.Command{
 	Use:   "proxy [voter name] [proxy name]",
-	Short: "Cast your vote for a proxy voter",
+	Short: "Proxy your vote strength to a proxy.",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/voteRecast.go
+++ b/eosc/cmd/voteRecast.go
@@ -10,7 +10,7 @@ import (
 
 var voteRecastCmd = &cobra.Command{
 	Use:   "recast [voter name]",
-	Short: "Recast your vote for the same producers.",
+	Short: "Recast your vote for the same producers or proxy.",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/voteRecast.go
+++ b/eosc/cmd/voteRecast.go
@@ -10,7 +10,7 @@ import (
 
 var voteRecastCmd = &cobra.Command{
 	Use:   "recast [voter name]",
-	Short: "Recast your vote for the same producers",
+	Short: "Recast your vote for the same producers.",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		api := getAPI()

--- a/eosc/cmd/voteStatus.go
+++ b/eosc/cmd/voteStatus.go
@@ -51,7 +51,7 @@ var voteStatusCmd = &cobra.Command{
 				} else {
 					fmt.Println("Producers list: ", info.Producers)
 					fmt.Println("Staked amount: ", info.Staked)
-					fmt.Println("Last vote weight: ", info.LastVoteWeight)
+					fmt.Printf("Last vote weight: %f\n", info.LastVoteWeight)
 				}
 			}
 		}


### PR DESCRIPTION
- Addressed  feedback from @joshkauffman raised in #45

@joshkauffman please note that Registering as proxy already exists under `eosc system regproxy`. That is because `regproxy` is a system contract features (like `regproducer`).

End-user voting was given its own 1st-level command to make it more accessible, while registering as a proxy remains a super user feature ...