### PR TITLE
Added support for binary output of tables

### DIFF
--- a/eosc/cmd/getTable.go
+++ b/eosc/cmd/getTable.go
@@ -23,7 +23,7 @@ var getTableCmd = &cobra.Command{
 				Code:  args[0],
 				Scope: args[1],
 				Table: args[2],
-				JSON:  true,
+				JSON:  !(viper.GetBool("get-table-cmd-output-binary")),
 				Limit: uint32(viper.GetInt("get-table-cmd-limit")),
 			},
 		)
@@ -40,8 +40,9 @@ func init() {
 	getCmd.AddCommand(getTableCmd)
 
 	getTableCmd.Flags().IntP("limit", "", 100, "Maximum number of rows to return.")
+	getTableCmd.Flags().Bool("output-binary", false, "Outputs the row-level data as hex-encoded binary instead of deserializing using the ABI")
 
-	for _, flag := range []string{"limit"} {
+	for _, flag := range []string{"limit", "output-binary"} {
 		if err := viper.BindPFlag("get-table-cmd-"+flag, getTableCmd.Flags().Lookup(flag)); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
```
$ eosc get table eosforumdapp eosforumdapp status --limit=1 --output-binary
{
  "more": true,
  "rows": [
    "80a9ba6a2a16b036236465762e656f73746f6f6c6b69742e696f2068617320656f73696f20666f72756d2121260a5f5b"
  ]
}
```

Resolves #29 