### PR TITLE
Adding bounds search support in get table

### DIFF
--- a/eosc/cmd/getTable.go
+++ b/eosc/cmd/getTable.go
@@ -20,11 +20,16 @@ var getTableCmd = &cobra.Command{
 
 		response, err := api.GetTableRows(
 			eos.GetTableRowsRequest{
-				Code:  args[0],
-				Scope: args[1],
-				Table: args[2],
-				JSON:  !(viper.GetBool("get-table-cmd-output-binary")),
-				Limit: uint32(viper.GetInt("get-table-cmd-limit")),
+				Code:       args[0],
+				Scope:      args[1],
+				Table:      args[2],
+				LowerBound: viper.GetString("get-table-cmd-lower-bound"),
+				UpperBound: viper.GetString("get-table-cmd-upper-bound"),
+				Limit:      uint32(viper.GetInt("get-table-cmd-limit")),
+				KeyType:    viper.GetString("get-table-cmd-key-type"),
+				Index:      viper.GetString("get-table-cmd-index"),
+				EncodeType: viper.GetString("get-table-cmd-encode-type"),
+				JSON:       !(viper.GetBool("get-table-cmd-output-binary")),
 			},
 		)
 		errorCheck("get table rows", err)
@@ -39,10 +44,15 @@ var getTableCmd = &cobra.Command{
 func init() {
 	getCmd.AddCommand(getTableCmd)
 
-	getTableCmd.Flags().IntP("limit", "", 100, "Maximum number of rows to return.")
+	getTableCmd.Flags().String("lower-bound", "", "Lower bound (incluse) value of key, defaults to first.")
+	getTableCmd.Flags().String("upper-bound", "", "Upper bound (exclusive) value of key, defaults to first.")
+	getTableCmd.Flags().String("key-type", "", "The key type of --index, primary only supports (i64), all others support (i64, i128, i256, float64, float128, ripemd160, sha256). Special type 'name' indicates an account name.")
+	getTableCmd.Flags().String("index", "", "Index number, 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc. Number or name of index can be specified, e.g. 'secondary' or '2'.")
+	getTableCmd.Flags().String("encode-type", "", "The encoding type of key-type (i64 , i128 , float64, float128) only support decimal encoding e.g. 'dec.  i256 - supports both 'dec' and 'hex', ripemd160 and sha256 is 'hex' only.")
+	getTableCmd.Flags().Int("limit", 100, "Maximum number of rows to return.")
 	getTableCmd.Flags().Bool("output-binary", false, "Outputs the row-level data as hex-encoded binary instead of deserializing using the ABI")
 
-	for _, flag := range []string{"limit", "output-binary"} {
+	for _, flag := range []string{"lower-bound", "upper-bound", "key-type", "index", "encode-type", "limit", "output-binary"} {
 		if err := viper.BindPFlag("get-table-cmd-"+flag, getTableCmd.Flags().Lookup(flag)); err != nil {
 			panic(err)
 		}

--- a/eosc/cmd/toolsChainFreeze.go
+++ b/eosc/cmd/toolsChainFreeze.go
@@ -27,7 +27,7 @@ var toolsChainFreezeCmd = &cobra.Command{
 		)
 
 		proxy.RegisterHandler(chainFreezeHandler)
-		err = proxy.Start("") //TODO Remove "" when unused arg is dropped
+		err = proxy.Start()
 		errorCheck("client start", err)
 	},
 }

--- a/vendor/github.com/eoscanada/eos-go/p2p/client.go
+++ b/vendor/github.com/eoscanada/eos-go/p2p/client.go
@@ -52,7 +52,7 @@ func (c *Client) read(peer *Peer, errChannel chan error) {
 
 		switch m := packet.P2PMessage.(type) {
 		case *eos.GoAwayMessage:
-			log.Fatalf("handling message: go away: %s", m.Reason)
+			errChannel <- fmt.Errorf("GoAwayMessage reason [%s]: %s", m.Reason, err)
 
 		case *eos.HandshakeMessage:
 			fmt.Println("Handshake resent!")

--- a/vendor/github.com/eoscanada/eos-go/p2p/peer.go
+++ b/vendor/github.com/eoscanada/eos-go/p2p/peer.go
@@ -33,6 +33,7 @@ type Peer struct {
 
 type HandshakeInfo struct {
 	ChainID                  eos.SHA256Bytes
+	ConnectingPeerAddress    string
 	HeadBlockNum             uint32
 	HeadBlockID              eos.SHA256Bytes
 	HeadBlockTime            time.Time
@@ -73,12 +74,12 @@ func NewOutgoingPeer(address string, agent string, handshakeInfo *HandshakeInfo)
 
 func (p *Peer) Read() (*eos.Packet, error) {
 	packet, err := eos.ReadPacket(p.reader)
+	if p.handshakeTimeout > 0 {
+		p.cancelHandshakeTimeout <- true
+	}
 	if err != nil {
 		log.Println("Connection Read error:", p.Address, err)
 		return nil, fmt.Errorf("connection: read: %s", err)
-	}
-	if p.handshakeTimeout > 0 {
-		p.cancelHandshakeTimeout <- true
 	}
 	return packet, nil
 }
@@ -126,6 +127,9 @@ func (p *Peer) Connect(errChan chan error) (ready chan bool) {
 			log.Printf("Dialing: %s, timeout: %d\n", p.Address, p.connectionTimeout)
 			conn, err := net.DialTimeout("tcp", p.Address, p.connectionTimeout)
 			if err != nil {
+				if p.handshakeTimeout > 0 {
+					p.cancelHandshakeTimeout <- true
+				}
 				errChan <- fmt.Errorf("peer init: dial %s: %s", p.Address, err)
 				return
 			}
@@ -229,7 +233,7 @@ func (p *Peer) SendHandshake(info *HandshakeInfo) (err error) {
 		Time:                     tstamp,
 		Token:                    make([]byte, 32, 32), // token[:]
 		Signature:                signature,
-		P2PAddress:               p.Address,
+		P2PAddress:               info.ConnectingPeerAddress,
 		LastIrreversibleBlockNum: info.LastIrreversibleBlockNum,
 		LastIrreversibleBlockID:  info.LastIrreversibleBlockID,
 		HeadNum:                  info.HeadBlockNum,

--- a/vendor/github.com/eoscanada/eos-go/p2p/proxy.go
+++ b/vendor/github.com/eoscanada/eos-go/p2p/proxy.go
@@ -74,9 +74,9 @@ func triggerHandshake(peer *Peer) error {
 	return peer.SendHandshake(peer.handshakeInfo)
 }
 
-func (p *Proxy) ConnectAndStart(chainID string) error {
+func (p *Proxy) ConnectAndStart() error {
 
-	log.Println("Connecting and starting proxy with chain id:", chainID)
+	log.Println("Connecting and starting proxy")
 
 	errorChannel := make(chan error)
 
@@ -100,11 +100,11 @@ func (p *Proxy) ConnectAndStart(chainID string) error {
 		}
 	}
 
-	return p.Start(chainID)
+	return p.Start()
 
 }
 
-func (p *Proxy) Start(chainID string) error {
+func (p *Proxy) Start() error {
 
 	log.Println("Starting readers")
 	errorChannel := make(chan error)

--- a/vendor/github.com/eoscanada/eos-go/p2p/relay.go
+++ b/vendor/github.com/eoscanada/eos-go/p2p/relay.go
@@ -42,7 +42,7 @@ func (r *Relay) startProxy(conn net.Conn) {
 
 		proxy.RegisterHandlers(r.handlers)
 
-		err := proxy.Start("")
+		err := proxy.Start()
 		fmt.Printf("Started proxy error between %s and %s : %s\n", remoteAddress, r.destinationPeerAddress, err)
 		destinationPeer.connection.Close()
 		remotePeer.connection.Close()

--- a/vendor/github.com/eoscanada/eos-go/responses.go
+++ b/vendor/github.com/eoscanada/eos-go/responses.go
@@ -180,14 +180,16 @@ type CurrencyBalanceResp struct {
 }
 
 type GetTableRowsRequest struct {
-	JSON       bool   `json:"json"`
+	Code       string `json:"code"` // Contract "code" account where table lives
 	Scope      string `json:"scope"`
-	Code       string `json:"code"`
 	Table      string `json:"table"`
-	TableKey   string `json:"table_key"`
-	LowerBound string `json:"lower_bound"`
-	UpperBound string `json:"upper_bound"`
-	Limit      uint32 `json:"limit,omitempty"` // defaults to 10 => chain_plugin.hpp:struct get_table_rows_params
+	LowerBound string `json:"lower_bound,omitempty"`
+	UpperBound string `json:"upper_bound,omitempty"`
+	Limit      uint32 `json:"limit,omitempty"`          // defaults to 10 => chain_plugin.hpp:struct get_table_rows_params
+	KeyType    string `json:"key_type,omitempty"`       // The key type of --index, primary only supports (i64), all others support (i64, i128, i256, float64, float128, ripemd160, sha256). Special type 'name' indicates an account name.
+	Index      string `json:"index_position,omitempty"` // Index number, 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc. Number or name of index can be specified, e.g. 'secondary' or '2'.
+	EncodeType string `json:"encode_type,omitempty"`    // The encoding type of key_type (i64 , i128 , float64, float128) only support decimal encoding e.g. 'dec'" "i256 - supports both 'dec' and 'hex', ripemd160 and sha256 is 'hex' only
+	JSON       bool   `json:"json"`                     // JSON output if true, binary if false
 }
 
 type GetTableRowsResp struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,71 +21,71 @@
 			"revisionTime": "2018-02-21T22:46:20Z"
 		},
 		{
-			"checksumSHA1": "Fyb+TwxyEYydkllVXBe7iiNC3tw=",
+			"checksumSHA1": "k2SbthHN6qsHZxgfVCchVu0yrcM=",
 			"path": "github.com/eoscanada/eos-go",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z",
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z",
 			"version": "master"
 		},
 		{
 			"checksumSHA1": "mbdurDenl8bhRVVu8ixJw70fi5E=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcd/btcec",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "9CdGdJ/+qjIwCfyoxoB3JxNtdyg=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcutil",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "VkjW+vswsv7J0PX2UFqqg+/RVgs=",
 			"path": "github.com/eoscanada/eos-go/btcsuite/btcutil/base58",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "zM0evxNx+urvLIkrJ3G9UdHNiUo=",
 			"path": "github.com/eoscanada/eos-go/ecc",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "GVFGhEfGI9Rpz6KF+c4S2YqAojI=",
 			"path": "github.com/eoscanada/eos-go/forum",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "Gk4Dvc3QqbWnUdz4jvCXuxULqyo=",
 			"path": "github.com/eoscanada/eos-go/msig",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
-			"checksumSHA1": "mTgHIIlH7S5q124/bVw9T+j29Rg=",
+			"checksumSHA1": "H9CHKrYMZjMkspTz3uMYXkOoVY4=",
 			"path": "github.com/eoscanada/eos-go/p2p",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "k9urFt9aTmOSSOfM8HCd178pbmM=",
 			"path": "github.com/eoscanada/eos-go/sudo",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "INVxgDwm7w2DfWELXYgyj87PSEE=",
 			"path": "github.com/eoscanada/eos-go/system",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "n/7xl3TEdpCXXT0GtNAxva/ReoI=",
 			"path": "github.com/eoscanada/eos-go/token",
-			"revision": "a7b32698e6e83957fbe6db16c790e69ec968e7b4",
-			"revisionTime": "2018-09-12T18:29:59Z"
+			"revision": "e281c685ee22486df8e059bab8c43f763d0677bb",
+			"revisionTime": "2018-09-16T22:06:13Z"
 		},
 		{
 			"checksumSHA1": "7NP1qUMF8Kx1y0zANxx0e+oq9Oo=",


### PR DESCRIPTION
This adds missing flags to `get table` allowing upper / lower bound indexed search.
Some features (`encode-type` will only work on mainnet when we update to `v1.2.x`)
---
Updated `govendor` to match `eos-go` master (had to add those to the lib)

Resolves #30 