### PR TITLE
The `tools names` command now accepts multiple arguments

### DIFF
--- a/eosc/cmd/toolsNames.go
+++ b/eosc/cmd/toolsNames.go
@@ -15,98 +15,113 @@ import (
 )
 
 var toolsNamesCmd = &cobra.Command{
-	Use:   "names [value]",
-	Short: "Convert a value to and from name-encoded strings",
+	Use:   "names value [value ...]",
+	Short: "Convert value(s) to and from name-encoded strings",
 	Long: `EOS name encoding creates strings or up to 12 characters out of uint64 values.
 
 This command auto-detects encoding and converts it to different encodings.
 `,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		input := args[0]
+		showHeader := len(args) > 1
 
-		showFrom := map[string]uint64{}
+		if showHeader {
+			// Add a starting blank line just like the command with 1 argument
+			fmt.Println()
+		}
 
-		baseHex, err := hex.DecodeString(input)
-		if err == nil {
-			if len(baseHex) == 8 {
-				showFrom["hex"] = binary.LittleEndian.Uint64(baseHex)
-				showFrom["hex_be"] = binary.BigEndian.Uint64(baseHex)
-			} else if len(baseHex) == 4 {
-				showFrom["hex"] = uint64(binary.LittleEndian.Uint32(baseHex))
-				showFrom["hex_be"] = uint64(binary.BigEndian.Uint32(baseHex))
+		for _, input := range args {
+			if showHeader {
+				fmt.Printf("  # %s", input)
 			}
+
+			printName(input)
 		}
-
-		fromSymbol, err := eos.StringToSymbol(input)
-		if err == nil {
-			symbolUint, err := fromSymbol.ToUint64()
-			if err == nil {
-				showFrom["symbol"] = symbolUint
-			}
-		}
-
-		fromSymbolCode, err := eos.StringToSymbolCode(input)
-		if err == nil {
-			showFrom["symbol_code"] = uint64(fromSymbolCode)
-		}
-
-		fromName, err := eos.StringToName(input)
-		if err == nil {
-			showFrom["name"] = fromName
-		}
-
-		fromUint64, err := strconv.ParseUint(input, 10, 64)
-		if err == nil {
-			showFrom["uint64"] = fromUint64
-		}
-
-		someFound := false
-		rows := []string{"| from \\ to | hex | hex_be | name | uint64 | symbol | symbol_code", "| --------- | --- | ------ | ---- | ------ | ------ | ----------- |"}
-		for _, from := range []string{"hex", "hex_be", "name", "uint64", "symbol", "symbol_code"} {
-			val, found := showFrom[from]
-			if !found {
-				continue
-			}
-			someFound = true
-
-			row := []string{from}
-			for _, to := range []string{"hex", "hex_be", "name", "uint64", "symbol", "symbol_code"} {
-
-				cnt := make([]byte, 8)
-				switch to {
-				case "hex":
-					binary.LittleEndian.PutUint64(cnt, val)
-					row = append(row, hex.EncodeToString(cnt))
-				case "hex_be":
-					binary.BigEndian.PutUint64(cnt, val)
-					row = append(row, hex.EncodeToString(cnt))
-
-				case "name":
-					row = append(row, eos.NameToString(val))
-
-				case "uint64":
-					row = append(row, strconv.FormatUint(val, 10))
-
-				case "symbol":
-					row = append(row, symbOrDash(fmt.Sprintf("%d,%s", uint8(val&0xFF), eos.SymbolCode(val>>8).String())))
-
-				case "symbol_code":
-					row = append(row, symbOrDash(eos.SymbolCode(val).String()))
-				}
-			}
-			rows = append(rows, "| "+strings.Join(row, " | ")+" |")
-		}
-
-		if !someFound {
-			fmt.Printf("Couldn't decode %q with any of these methods: hex, hex_be, name, uint64\n", input)
-			os.Exit(1)
-		}
-
-		fmt.Println("")
-		fmt.Println(columnize.SimpleFormat(rows))
-		fmt.Println("")
 	},
+}
+
+func printName(input string) {
+	showFrom := map[string]uint64{}
+
+	baseHex, err := hex.DecodeString(input)
+	if err == nil {
+		if len(baseHex) == 8 {
+			showFrom["hex"] = binary.LittleEndian.Uint64(baseHex)
+			showFrom["hex_be"] = binary.BigEndian.Uint64(baseHex)
+		} else if len(baseHex) == 4 {
+			showFrom["hex"] = uint64(binary.LittleEndian.Uint32(baseHex))
+			showFrom["hex_be"] = uint64(binary.BigEndian.Uint32(baseHex))
+		}
+	}
+
+	fromSymbol, err := eos.StringToSymbol(input)
+	if err == nil {
+		symbolUint, err := fromSymbol.ToUint64()
+		if err == nil {
+			showFrom["symbol"] = symbolUint
+		}
+	}
+
+	fromSymbolCode, err := eos.StringToSymbolCode(input)
+	if err == nil {
+		showFrom["symbol_code"] = uint64(fromSymbolCode)
+	}
+
+	fromName, err := eos.StringToName(input)
+	if err == nil {
+		showFrom["name"] = fromName
+	}
+
+	fromUint64, err := strconv.ParseUint(input, 10, 64)
+	if err == nil {
+		showFrom["uint64"] = fromUint64
+	}
+
+	someFound := false
+	rows := []string{"| from \\ to | hex | hex_be | name | uint64 | symbol | symbol_code", "| --------- | --- | ------ | ---- | ------ | ------ | ----------- |"}
+	for _, from := range []string{"hex", "hex_be", "name", "uint64", "symbol", "symbol_code"} {
+		val, found := showFrom[from]
+		if !found {
+			continue
+		}
+		someFound = true
+
+		row := []string{from}
+		for _, to := range []string{"hex", "hex_be", "name", "uint64", "symbol", "symbol_code"} {
+
+			cnt := make([]byte, 8)
+			switch to {
+			case "hex":
+				binary.LittleEndian.PutUint64(cnt, val)
+				row = append(row, hex.EncodeToString(cnt))
+			case "hex_be":
+				binary.BigEndian.PutUint64(cnt, val)
+				row = append(row, hex.EncodeToString(cnt))
+
+			case "name":
+				row = append(row, eos.NameToString(val))
+
+			case "uint64":
+				row = append(row, strconv.FormatUint(val, 10))
+
+			case "symbol":
+				row = append(row, symbOrDash(fmt.Sprintf("%d,%s", uint8(val&0xFF), eos.SymbolCode(val>>8).String())))
+
+			case "symbol_code":
+				row = append(row, symbOrDash(eos.SymbolCode(val).String()))
+			}
+		}
+		rows = append(rows, "| "+strings.Join(row, " | ")+" |")
+	}
+
+	if !someFound {
+		fmt.Printf("Couldn't decode %q with any of these methods: hex, hex_be, name, uint64\n", input)
+		os.Exit(1)
+	}
+
+	fmt.Println("")
+	fmt.Println(columnize.SimpleFormat(rows))
+	fmt.Println("")
 }
 
 var symbOrDashRE = regexp.MustCompile(`^[0-9A-Z,]+$`)


### PR DESCRIPTION
The output when 1 argument is provided is exactly the same as before. When more than 1 argument is provided, each input is written in a section of the form:

```
  # <input>
  ... (same print as 1 argument)

  # ...
```

#### PR Output

```
$ eosc tools names 3d3aaa638e984430 3ab195531c74d570

  # 3d3aaa638e984430
  from \ to  hex               hex_be            name           uint64               symbol  symbol_code
  ---------  ---               ------            ----           ------               ------  -----------
  hex        3d3aaa638e984430  3044988e63aa3a3d  a12dl3n3pcx3h  3478072549561743933  -       -
  hex_be     3044988e63aa3a3d  3d3aaa638e984430  boxeoswin123   4412026129533649968  -       -
  name       048002031863461a  1a46631803028004  3d3aaa.3.e..4  1893309648136732676  -       -

  # 3ab195531c74d570
  from \ to  hex               hex_be            name           uint64               symbol  symbol_code
  ---------  ---               ------            ----           ------               ------  -----------
  hex        3ab195531c74d570  70d5741c5395b13a  i3ercb2nmqsne  8130532367297524026  -       -
  hex_be     70d5741c5395b13a  3ab195531c74d570  besteoswiner   4229325709269849456  -       -
  name       49000aa314108e19  198e1014a30a0049  3ab1.5531c.4d  1841426978461843529  -       -
```