### PR TITLE
Fixed `--json ...` flag not working on `eosc forum vote`

### DIFF
--- a/eosc/cmd/forumVote.go
+++ b/eosc/cmd/forumVote.go
@@ -35,7 +35,7 @@ var forumVoteCmd = &cobra.Command{
 			errorCheck("vote value cannot exceed 255", fmt.Errorf("vote value too high: %d", voteValue))
 		}
 
-		json := viper.GetString("forum-cmd-target-json")
+		json := viper.GetString("forum-vote-cmd-json")
 
 		action := forum.NewVote(voter, proposalName, uint8(voteValue), json)
 		action.Account = targetAccount


### PR DESCRIPTION
The flag was simply not retrieved using the right key, and was empty even when provided through the command line. This is now fixed by using the right key to retrieve the `--json ...` flag value.

Fixes #129